### PR TITLE
Enable self transition

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -387,18 +387,6 @@ func (f *FSM) Event(ctx context.Context, event string, args ...interface{}) erro
 		return InternalError{}
 	}
 
-        // Moved this if block from line 335 to here
-        if f.current == dst {
-                // f.afterEventCallbacks needn't be called when the if block is moved here,
-                // because it is called in transitionFunc
-                //f.stateMu.RUnlock()
-                //defer f.stateMu.RLock()
-                //f.eventMu.Unlock()
-                //unlocked = true
-                //f.afterEventCallbacks(ctx, e)
-                return NoTransitionError{e.Err}
-        }
-
 	return e.Err
 }
 

--- a/fsm.go
+++ b/fsm.go
@@ -332,15 +332,6 @@ func (f *FSM) Event(ctx context.Context, event string, args ...interface{}) erro
 		return err
 	}
 
-	if f.current == dst {
-		f.stateMu.RUnlock()
-		defer f.stateMu.RLock()
-		f.eventMu.Unlock()
-		unlocked = true
-		f.afterEventCallbacks(ctx, e)
-		return NoTransitionError{e.Err}
-	}
-
 	// Setup the transition, call it later.
 	transitionFunc := func(ctx context.Context, async bool) func() {
 		return func() {
@@ -395,6 +386,18 @@ func (f *FSM) Event(ctx context.Context, event string, args ...interface{}) erro
 	if err != nil {
 		return InternalError{}
 	}
+
+        // Moved this if block from line 335 to here
+        if f.current == dst {
+                // f.afterEventCallbacks needn't be called when the if block is moved here,
+                // because it is called in transitionFunc
+                //f.stateMu.RUnlock()
+                //defer f.stateMu.RLock()
+                //f.eventMu.Unlock()
+                //unlocked = true
+                //f.afterEventCallbacks(ctx, e)
+                return NoTransitionError{e.Err}
+        }
 
 	return e.Err
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/MonochromeHousing/fsm
 
-go 1.16
+go 1.22

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/looplab/fsm
+module github.com/MonochromeHousing/fsm
 
 go 1.16


### PR DESCRIPTION
This change causes self-transitions to run state callbacks for the state self-transitioned to, instead of ignoring the callback. The current looplab/fsm library, from which this was forked, checks for self-transition when running an Event and returns early, before running any state callbacks. We simply move that check to after state callbacks are run. The self-transition error is still returned, it just happens after we run the callback of the state that was self-transitioned to.